### PR TITLE
Fix #165 by using vanilla particle system

### DIFF
--- a/src/main/java/de/ellpeck/naturesaura/events/ClientEvents.java
+++ b/src/main/java/de/ellpeck/naturesaura/events/ClientEvents.java
@@ -180,9 +180,6 @@ public class ClientEvents {
     @SubscribeEvent
     public void onWorldRender(RenderWorldLastEvent event) {
         Minecraft mc = Minecraft.getInstance();
-        MatrixStack stack = event.getMatrixStack();
-        ParticleHandler.renderParticles(event.getMatrixStack(), mc.getRenderPartialTicks());
-
         RenderSystem.pushMatrix();
         RenderSystem.multMatrix(event.getMatrixStack().getLast().getMatrix());
 
@@ -252,7 +249,7 @@ public class ClientEvents {
             GL11.glPopMatrix();
         }
 
-        GL11.glPopMatrix();
+        RenderSystem.popMatrix();
     }
 
     private void renderVisualize(IVisualizable visualize, World

--- a/src/main/java/de/ellpeck/naturesaura/particles/ParticleMagic.java
+++ b/src/main/java/de/ellpeck/naturesaura/particles/ParticleMagic.java
@@ -28,6 +28,7 @@ public class ParticleMagic extends Particle {
     private final float desiredScale;
     private final boolean fade;
     private float particleScale;
+    private boolean depthEnabled = ParticleHandler.depthEnabled;
 
     public ParticleMagic(ClientWorld world, double posX, double posY, double posZ, double motionX, double motionY, double motionZ, int color, float scale, int maxAge, float gravity, boolean collision, boolean fade) {
         super(world, posX, posY, posZ);
@@ -119,7 +120,7 @@ public class ParticleMagic extends Particle {
 
     @Override
     public IParticleRenderType getRenderType() {
-        return IParticleRenderType.CUSTOM;
+        return depthEnabled ? ParticleRenderTypes.PARTICLE_MAGIC_TRANSLUCENT : ParticleRenderTypes.PARTICLE_MAGIC_TRANSLUCENT_NO_DEPTH;
     }
 
     @Override

--- a/src/main/java/de/ellpeck/naturesaura/particles/ParticleRenderTypes.java
+++ b/src/main/java/de/ellpeck/naturesaura/particles/ParticleRenderTypes.java
@@ -1,0 +1,65 @@
+package de.ellpeck.naturesaura.particles;
+
+import com.mojang.blaze3d.platform.GlStateManager.DestFactor;
+import com.mojang.blaze3d.platform.GlStateManager.SourceFactor;
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.particle.IParticleRenderType;
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import org.lwjgl.opengl.GL11;
+
+public class ParticleRenderTypes {
+    /**
+     * @see IParticleRenderType#PARTICLE_SHEET_TRANSLUCENT
+     */
+    public static final IParticleRenderType PARTICLE_MAGIC_TRANSLUCENT = new IParticleRenderType() {
+        public void beginRender(BufferBuilder buffer, TextureManager textureManager) {
+            setupTranslucent();
+
+            RenderSystem.enableDepthTest();
+            textureManager.bindTexture(ParticleMagic.TEXTURE);
+            buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.PARTICLE_POSITION_TEX_COLOR_LMAP);
+        }
+
+        public void finishRender(Tessellator tessellator) {
+            tessellator.draw();
+        }
+
+        public String toString() {
+            return "PARTICLE_MAGIC_TRANSLUCENT";
+        }
+    };
+    /**
+     * Same as PARTICLE_MAGIC_TRANSLUCENT but without depth test
+     */
+    public static final IParticleRenderType PARTICLE_MAGIC_TRANSLUCENT_NO_DEPTH = new IParticleRenderType() {
+        public void beginRender(BufferBuilder buffer, TextureManager textureManager) {
+            setupTranslucent();
+
+            RenderSystem.disableDepthTest();
+            textureManager.bindTexture(ParticleMagic.TEXTURE);
+            buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.PARTICLE_POSITION_TEX_COLOR_LMAP);
+        }
+
+        public void finishRender(Tessellator tessellator) {
+            tessellator.draw();
+        }
+
+        public String toString() {
+            return "PARTICLE_MAGIC_TRANSLUCENT_NO_DEPTH";
+        }
+    };
+
+    public static void setupTranslucent() {
+        RenderSystem.depthMask(false);
+        RenderSystem.enableBlend();
+        RenderSystem.blendFunc(SourceFactor.SRC_ALPHA, DestFactor.ONE_MINUS_SRC_ALPHA);
+        RenderSystem.enableAlphaTest();
+        RenderSystem.alphaFunc(516, 0.003921569F);
+        RenderSystem.disableCull();
+        RenderSystem.enableFog();
+        RenderSystem.color4f(1.0F, 1.0F, 1.0F, 1.0F);
+    }
+}


### PR DESCRIPTION
## Description
Fixes the rendering problems in #165 

But introduces a rendering bug: Particles end up rendering behind clouds.

This could be fixed by leaving the depth mask on, but the issue with that is vanilla doesn't sort particle rendering by distance from view point like it should so then you have issues when a translucent particle closer than another particle is rendered before it (see 3rd screenshot).

Prior to this change, the reason why nature's aura particles rendered in front of clouds was because it was rendered after clouds.

I'm not really sure this this PR is even merge worthy tbh... Feel free to close it for something better.

e.g. Probably would be more proper to register the particle with vanilla and have it be part of the particle texture

## Screenshots

**Before**
![2020-12-04_17 10 32](https://user-images.githubusercontent.com/630920/101147258-19edc680-3657-11eb-9a9b-f5584ea2b7be.png)

**After**
![2020-12-04_17 08 42](https://user-images.githubusercontent.com/630920/101147316-2c680000-3657-11eb-99d8-6861c051b215.png)

**Particle Order example**
![2020-12-04_17 34 51](https://user-images.githubusercontent.com/630920/101147457-5d483500-3657-11eb-9f6a-8f205b100f43.png)
