### PR TITLE
Prevent crash when using sundial outside of overworld

### DIFF
--- a/src/main/java/de/ellpeck/naturesaura/blocks/tiles/TileEntityTimeChanger.java
+++ b/src/main/java/de/ellpeck/naturesaura/blocks/tiles/TileEntityTimeChanger.java
@@ -19,7 +19,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.GameRules;
 import net.minecraft.world.server.ServerWorld;
-import net.minecraft.world.storage.ServerWorldInfo;
+import net.minecraft.world.storage.IServerWorldInfo;
 
 import java.util.List;
 
@@ -48,7 +48,7 @@ public class TileEntityTimeChanger extends TileEntityImpl implements ITickableTi
                         this.sendToClients();
                         return;
                     }
-                    ((ServerWorldInfo) this.world.getWorldInfo()).setDayTime(current + toAdd);
+                    ((IServerWorldInfo) this.world.getWorldInfo()).setDayTime(current + toAdd);
 
                     BlockPos spot = IAuraChunk.getHighestSpot(this.world, this.pos, 35, this.pos);
                     IAuraChunk.getAuraChunk(this.world, spot).drainAura(spot, (int) toAdd * 20);


### PR DESCRIPTION
Reported here: AllTheMods/ATM-6#1670

Full crash log: https://gist.github.com/jeremiahwinsley/d2a5a379ec99bb9f501bb2d20a2e2926

In dimensions outside of the overworld, `getWorldInfo` returns `DerivedWorldInfo` rather than `ServerWorldInfo`. 

Switching to `IServerWorldInfo` prevents this crash.



