### PR TITLE
Add range parameter to `/naaura reset`

### DIFF
--- a/src/main/java/de/ellpeck/naturesaura/commands/CommandAura.java
+++ b/src/main/java/de/ellpeck/naturesaura/commands/CommandAura.java
@@ -34,10 +34,11 @@ public final class CommandAura {
                     source.sendFeedback(new StringTextComponent("Removed aura from area"), true);
                     return 0;
                 })))
-                .then(Commands.literal("reset").executes(context -> {
+                .then(Commands.literal("reset").then(Commands.argument("range", IntegerArgumentType.integer(1)).executes(context -> {
+                    int range = IntegerArgumentType.getInteger(context, "range");
                     CommandSource source = context.getSource();
                     BlockPos pos = new BlockPos(source.getPos());
-                    IAuraChunk.getSpotsInArea(source.getWorld(), pos, 35, (spot, amount) -> {
+                    IAuraChunk.getSpotsInArea(source.getWorld(), pos, range, (spot, amount) -> {
                         IAuraChunk chunk = IAuraChunk.getAuraChunk(source.getWorld(), spot);
                         if (amount > 0)
                             chunk.drainAura(spot, amount);
@@ -46,6 +47,6 @@ public final class CommandAura {
                     });
                     source.sendFeedback(new StringTextComponent("Reset aura in area"), true);
                     return 0;
-                })));
+                }))));
     }
 }


### PR DESCRIPTION
`/naaura reset` has a tiny range by default (35 blocks). I was flying around spamming this command before I realized aura can spread into vertical chunks. If one were to cause a massive cascade from excessive aura generation, it becomes almost impossible to fix without flying around in debug mode and running the command in mid air (or, worse, underground).

This could be perceived as papering over the underlying problem (#246), but this simple change did help me restore an area that was causing a lot of TPS issues from aura overproduction. I'm not sure of the implications are of a range greater than `35`, but it seemed to work as expected.