### PR TITLE
Add null check in `BlockSpring#getBlockColor`

### DIFF
--- a/src/main/java/de/ellpeck/naturesaura/blocks/BlockSpring.java
+++ b/src/main/java/de/ellpeck/naturesaura/blocks/BlockSpring.java
@@ -33,7 +33,7 @@ public class BlockSpring extends BlockContainerImpl implements ICustomBlockState
     @Override
     @OnlyIn(Dist.CLIENT)
     public BlockColor getBlockColor() {
-        return (state, level, pos, i) -> BiomeColors.getAverageWaterColor(level, pos);
+        return (state, level, pos, i) -> level == null || pos == null ? -1 : BiomeColors.getAverageWaterColor(level, pos);
     }
 
     @Override


### PR DESCRIPTION
This pull request fixes #320 by adding a null check for both the world and position arguments in the `BlockSpring#getBlockColor` lambda. If either argument is null, the method will simply return 0 as is the case for `BlockSpring#getItemColor`.

```diff
    @Override
    @OnlyIn(Dist.CLIENT)
    public BlockColor getBlockColor() {
-       return (state, level, pos, i) -> BiomeColors.getAverageWaterColor(level, pos);
+       return (state, level, pos, i) -> level == null || pos == null ? -1 : BiomeColors.getAverageWaterColor(level, pos);
    }
```