### PR TITLE
Allow plant boost and client magic particles to work even if there isn't air above plants, leaves, and mycelium

### DIFF
--- a/src/main/java/de/ellpeck/naturesaura/Helper.java
+++ b/src/main/java/de/ellpeck/naturesaura/Helper.java
@@ -319,6 +319,20 @@ public final class Helper {
         return ItemStack.EMPTY;
     }
 
+    public static BlockPos getClosestBonemealableBlock(Level level, BlockPos pos, int radius) {
+        for (var i = 0; i < radius; i++) {
+            var up = pos.above(i);
+            Block block = level.getBlockState(up).getBlock();
+            if (block instanceof BonemealableBlock)
+                return up;
+            var dn = pos.below(i);
+            block = level.getBlockState(dn).getBlock();
+            if (block instanceof BonemealableBlock)
+                return dn;
+        }
+        return pos;
+    }
+
     public static BlockPos getClosestNatureBlock(Level level, BlockPos pos, int radius) {
         for (var i = 0; i < radius; i++) {
             var up = pos.above(i);

--- a/src/main/java/de/ellpeck/naturesaura/Helper.java
+++ b/src/main/java/de/ellpeck/naturesaura/Helper.java
@@ -36,9 +36,7 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.BonemealableBlock;
+import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.Property;
@@ -324,10 +322,12 @@ public final class Helper {
     public static BlockPos getClosestBonemealableBlock(Level level, BlockPos pos, int radius) {
         for (var i = 0; i < radius; i++) {
             var up = pos.above(i);
-            if (level.getBlockState(up).getBlock() instanceof BonemealableBlock)
+            Block block = level.getBlockState(up).getBlock();
+            if (block instanceof BonemealableBlock || block instanceof LeavesBlock || block instanceof MyceliumBlock)
                 return up;
             var dn = pos.below(i);
-            if (level.getBlockState(dn).getBlock() instanceof BonemealableBlock)
+            block = level.getBlockState(dn).getBlock();
+            if (block instanceof BonemealableBlock || block instanceof LeavesBlock || block instanceof MyceliumBlock)
                 return dn;
         }
         return pos;

--- a/src/main/java/de/ellpeck/naturesaura/Helper.java
+++ b/src/main/java/de/ellpeck/naturesaura/Helper.java
@@ -322,12 +322,12 @@ public final class Helper {
     public static BlockPos getClosestBonemealableBlock(Level level, BlockPos pos, int radius) {
         for (var i = 0; i < radius; i++) {
             var up = pos.above(i);
-            Block block = level.getBlockState(up).getBlock();
-            if (block instanceof BonemealableBlock)
+//      check if this is the top of a bonemealable block.
+            if ((level.getBlockState(up).getBlock() instanceof BonemealableBlock) && !(level.getBlockState(up.above()) instanceof BonemealableBlock))
                 return up;
             var dn = pos.below(i);
-            block = level.getBlockState(dn).getBlock();
-            if (block instanceof BonemealableBlock)
+//      check if this is the top of a bonemealable block.
+            if ((level.getBlockState(dn).getBlock() instanceof BonemealableBlock)  && !(level.getBlockState(dn.above()) instanceof BonemealableBlock))
                 return dn;
         }
         return pos;

--- a/src/main/java/de/ellpeck/naturesaura/Helper.java
+++ b/src/main/java/de/ellpeck/naturesaura/Helper.java
@@ -38,6 +38,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.BonemealableBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.Property;
@@ -320,13 +321,13 @@ public final class Helper {
         return ItemStack.EMPTY;
     }
 
-    public static BlockPos getClosestAirAboveGround(Level level, BlockPos pos, int radius) {
+    public static BlockPos getClosestBonemealableBlock(Level level, BlockPos pos, int radius) {
         for (var i = 0; i < radius; i++) {
             var up = pos.above(i);
-            if (level.isEmptyBlock(up) && !level.isEmptyBlock(up.below()))
+            if (level.getBlockState(up).getBlock() instanceof BonemealableBlock)
                 return up;
             var dn = pos.below(i);
-            if (level.isEmptyBlock(dn) && !level.isEmptyBlock(dn.below()))
+            if (level.getBlockState(dn).getBlock() instanceof BonemealableBlock)
                 return dn;
         }
         return pos;

--- a/src/main/java/de/ellpeck/naturesaura/Helper.java
+++ b/src/main/java/de/ellpeck/naturesaura/Helper.java
@@ -36,9 +36,7 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.BonemealableBlock;
+import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.Property;
@@ -321,13 +319,15 @@ public final class Helper {
         return ItemStack.EMPTY;
     }
 
-    public static BlockPos getClosestBonemealableBlock(Level level, BlockPos pos, int radius) {
+    public static BlockPos getClosestNatureBlock(Level level, BlockPos pos, int radius) {
         for (var i = 0; i < radius; i++) {
             var up = pos.above(i);
-            if (level.getBlockState(up).getBlock() instanceof BonemealableBlock)
+            Block block = level.getBlockState(up).getBlock();
+            if (block instanceof BonemealableBlock || block instanceof LeavesBlock || block instanceof MyceliumBlock)
                 return up;
             var dn = pos.below(i);
-            if (level.getBlockState(dn).getBlock() instanceof BonemealableBlock)
+            block = level.getBlockState(dn).getBlock();
+            if (block instanceof BonemealableBlock || block instanceof LeavesBlock || block instanceof MyceliumBlock)
                 return dn;
         }
         return pos;

--- a/src/main/java/de/ellpeck/naturesaura/chunk/effect/PlantBoostEffect.java
+++ b/src/main/java/de/ellpeck/naturesaura/chunk/effect/PlantBoostEffect.java
@@ -71,7 +71,7 @@ public class PlantBoostEffect implements IDrainSpotEffect {
             var x = Mth.floor(pos.getX() + (2 * level.random.nextFloat() - 1) * this.dist);
             var y = Mth.floor(pos.getY() + (2 * level.random.nextFloat() - 1) * this.dist / 2);
             var z = Mth.floor(pos.getZ() + (2 * level.random.nextFloat() - 1) * this.dist);
-            var plantPos = Helper.getClosestAirAboveGround(level, new BlockPos(x, y, z), this.dist / 2).below();
+            var plantPos = Helper.getClosestBonemealableBlock(level, new BlockPos(x, y, z), this.dist / 2);
             if (plantPos.distSqr(pos) <= this.dist * this.dist && level.isLoaded(plantPos)) {
                 if (NaturesAuraAPI.instance().isEffectPowderActive(level, plantPos, PlantBoostEffect.NAME))
                     continue;

--- a/src/main/java/de/ellpeck/naturesaura/chunk/effect/PlantBoostEffect.java
+++ b/src/main/java/de/ellpeck/naturesaura/chunk/effect/PlantBoostEffect.java
@@ -71,7 +71,7 @@ public class PlantBoostEffect implements IDrainSpotEffect {
             var x = Mth.floor(pos.getX() + (2 * level.random.nextFloat() - 1) * this.dist);
             var y = Mth.floor(pos.getY() + (2 * level.random.nextFloat() - 1) * this.dist / 2);
             var z = Mth.floor(pos.getZ() + (2 * level.random.nextFloat() - 1) * this.dist);
-            var plantPos = Helper.getClosestNatureBlock(level, new BlockPos(x, y, z), this.dist / 2);
+            var plantPos = Helper.getClosestBonemealableBlock(level, new BlockPos(x, y, z), this.dist / 2);
             if (plantPos.distSqr(pos) <= this.dist * this.dist && level.isLoaded(plantPos)) {
                 if (NaturesAuraAPI.instance().isEffectPowderActive(level, plantPos, PlantBoostEffect.NAME))
                     continue;

--- a/src/main/java/de/ellpeck/naturesaura/chunk/effect/PlantBoostEffect.java
+++ b/src/main/java/de/ellpeck/naturesaura/chunk/effect/PlantBoostEffect.java
@@ -71,7 +71,7 @@ public class PlantBoostEffect implements IDrainSpotEffect {
             var x = Mth.floor(pos.getX() + (2 * level.random.nextFloat() - 1) * this.dist);
             var y = Mth.floor(pos.getY() + (2 * level.random.nextFloat() - 1) * this.dist / 2);
             var z = Mth.floor(pos.getZ() + (2 * level.random.nextFloat() - 1) * this.dist);
-            var plantPos = Helper.getClosestBonemealableBlock(level, new BlockPos(x, y, z), this.dist / 2);
+            var plantPos = Helper.getClosestNatureBlock(level, new BlockPos(x, y, z), this.dist / 2);
             if (plantPos.distSqr(pos) <= this.dist * this.dist && level.isLoaded(plantPos)) {
                 if (NaturesAuraAPI.instance().isEffectPowderActive(level, plantPos, PlantBoostEffect.NAME))
                     continue;

--- a/src/main/java/de/ellpeck/naturesaura/events/ClientEvents.java
+++ b/src/main/java/de/ellpeck/naturesaura/events/ClientEvents.java
@@ -110,7 +110,7 @@ public class ClientEvents {
                         var x = Mth.floor(mc.player.getX()) + mc.level.random.nextInt(64) - 32;
                         var y = Mth.floor(mc.player.getY()) + mc.level.random.nextInt(32) - 16;
                         var z = Mth.floor(mc.player.getZ()) + mc.level.random.nextInt(64) - 32;
-                        var pos = Helper.getClosestBonemealableBlock(mc.level, new BlockPos(x, y, z), 16);
+                        var pos = Helper.getClosestNatureBlock(mc.level, new BlockPos(x, y, z), 16);
                         var state = mc.level.getBlockState(pos);
                         var block = state.getBlock();
                         if (block instanceof BonemealableBlock || block instanceof LeavesBlock || block instanceof MyceliumBlock) {

--- a/src/main/java/de/ellpeck/naturesaura/events/ClientEvents.java
+++ b/src/main/java/de/ellpeck/naturesaura/events/ClientEvents.java
@@ -110,7 +110,7 @@ public class ClientEvents {
                         var x = Mth.floor(mc.player.getX()) + mc.level.random.nextInt(64) - 32;
                         var y = Mth.floor(mc.player.getY()) + mc.level.random.nextInt(32) - 16;
                         var z = Mth.floor(mc.player.getZ()) + mc.level.random.nextInt(64) - 32;
-                        var pos = Helper.getClosestAirAboveGround(mc.level, new BlockPos(x, y, z), 16).below();
+                        var pos = Helper.getClosestBonemealableBlock(mc.level, new BlockPos(x, y, z), 16);
                         var state = mc.level.getBlockState(pos);
                         var block = state.getBlock();
                         if (block instanceof BonemealableBlock || block instanceof LeavesBlock || block instanceof MyceliumBlock) {


### PR DESCRIPTION
This changes the function for checking for the closest air block above a point to checking for the closest bonemealable block that doesn't have another bonemealableblock directly above it.

It also splits the client random particles into a separate function mostly so that the server function for plant burst doesn't have to check for unnecessary things.

This could probably be optimised a bit more by removing the redundant checks for bonemealableblock in plantboosteffect.java and bonemealableblock, leavesblock, and myceliumblock in clientevents.java and instead returning null and checking against null, but it's not strictly necessary.

The final result of these changes is that plants with non-air blocks above them can still benefit from plant boost and plants, leaves, and mycelium with non-air blocks above them can still be counted for the client particles