### PR TITLE
Fix build failure.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,6 @@ repositories {
     maven {
         url = "https://maven.theillusivec4.top/"
     }
-    maven {
-        url = uri("https://maven.octo-studios.com/releases")
-    }
 }
 
 base {

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ neo_version_range=[21.1.0,)
 loader_version_range=[4,)
 
 jei_version=19.18.3.204
-curios_version=9.0.11+1.21
+curios_version=9.2.0+1.21.1
 patchouli_version=1.21-87-NEOFORGE
 
 ## Mod Properties


### PR DESCRIPTION
Updates the curios to the closest version I was able to find to the previous version that was listed in the gradle.properties and deletes a maven repository that no longer exists.

I don't know if this causes any issues with curio functionality(It doesn't appear to for my local build but I could be missing something)